### PR TITLE
Support dry-run flag

### DIFF
--- a/namespace.sh
+++ b/namespace.sh
@@ -2,12 +2,26 @@
 
 set -eu
 
+dryRun=""
+for i in $@; do
+    if [ "$i" = --dry-run ]; then
+        dryRun=1
+        break
+    fi
+done
+
 echo "Ensuring the namespace ${HELM_NAMESPACE} exists"
+
+if [ -n "$dryRun" ]; then
+    echo "DRY-RUN: no operations will really be performed"
+else
 
 echo "apiVersion: v1
 kind: Namespace
 metadata:
   name: ${HELM_NAMESPACE}
 " | kubectl apply -f -
+
+fi
 
 $HELM_BIN $@


### PR DESCRIPTION
Plugin is awesome!  I've started testing helm v3 with it. Thanks!

--

When using the --dry-run flag for helm install or helm upgrade,
it would be better not to really create the namespace.

Signed-off-by: Marc Khouzam <marc.khouzam@gmail.com>