### PR TITLE
Must pass HELM_CONTEXT to kubectl

### DIFF
--- a/namespace.sh
+++ b/namespace.sh
@@ -16,11 +16,14 @@ if [ -n "$dryRun" ]; then
     echo "DRY-RUN: no operations will really be performed"
 else
 
+context=""
+[ -n "${HELM_KUBECONTEXT}" ] && context="--context $HELM_KUBECONTEXT"
+
 echo "apiVersion: v1
 kind: Namespace
 metadata:
   name: ${HELM_NAMESPACE}
-" | kubectl apply -f -
+" | kubectl $context apply -f -
 
 fi
 


### PR DESCRIPTION
If 'helm namespace' is called with the '--kube-context' flag, it must
also be passed to kubectl, or else kubectl will create the namespace
in a different cluster.